### PR TITLE
fix UnboundLocalError for uptime0

### DIFF
--- a/check_iftraffic_nrpe.py
+++ b/check_iftraffic_nrpe.py
@@ -123,7 +123,10 @@ def load_data(filename, columns):
         else:
             data = line.split()
             # get the device name
-            device_name = data.pop(0)
+            try:
+                device_name = data.pop(0)
+            except IndexError:
+                raise ValueError("data file truncated")
             # transform values into integer
             data = map(int, data)
             # create a nice dictionnary of the values


### PR DESCRIPTION
This can happen when the data file is empty for whatever reason. It will
now be treated like a corrupt or old data file (i.e. removed).
