### PR TITLE
Added class Dummy_argparse for python 2.4/2.6 compatability, Performance data updates

### DIFF
--- a/check_iftraffic_nrpe.py
+++ b/check_iftraffic_nrpe.py
@@ -33,9 +33,12 @@ import socket
 import struct
 import sys
 import time
-if sys.hexversion >= 0x2070000:
+
+have_argparse=0
+try:
     import argparse
-else:
+    have_argparse=1
+except ImportError:
     class Dummy_argparse:
          warning=100
          critical=100
@@ -485,7 +488,7 @@ def main(default_values):
     # previous data
     if_data0 = None
     # The temporary file where data will be stored between to metrics
-    if sys.hexversion >= 0x2070000:
+    if have_argparse == 1:
         args = parse_arguments(default_values)
     else:
         args = Dummy_argparse
@@ -498,7 +501,7 @@ def main(default_values):
     ifdetect = InterfaceDetection()
 
     nagios_result = NagiosResult("Traffic %s" % args.unit)
-    if sys.hexversion < 0x2070000:
+    if have_argparse == 0:
         nagios_result.messages.append('python < 2.7, args ignored')
     #
     # Read current data


### PR DESCRIPTION
For python 2.4/2.6 compatability
- added the class Dummy_argparse for Python 2.4/2.6 compatibility
- check if class sys has the attribute maxsize, use constant 2^32-1 if not
- Performance data now outputs raw counters
- Performance data only put the warn/crit levels in the 1st set of values
- changed name of /var/tmp file to check_iftraffic_nrpe_stats.dat
